### PR TITLE
Remove unused throws

### DIFF
--- a/Middleware/src/main/java/ca/concordia/encs/citydata/core/contracts/IRunner.java
+++ b/Middleware/src/main/java/ca/concordia/encs/citydata/core/contracts/IRunner.java
@@ -28,6 +28,6 @@ public interface IRunner {
 	// receiving notifications from other entities
 	void newOperationApplied(IOperation<?> operation);
 
-	void newDataAvailable(IProducer<?> producer) throws Exception;
+	void newDataAvailable(IProducer<?> producer);
 
 }

--- a/Middleware/src/main/java/ca/concordia/encs/citydata/core/implementations/AbstractOperation.java
+++ b/Middleware/src/main/java/ca/concordia/encs/citydata/core/implementations/AbstractOperation.java
@@ -15,7 +15,7 @@ import ca.concordia.encs.citydata.core.exceptions.MiddlewareException;
  * This implements features common to all Operations, such as notifying Runners
  * 
  * @author Gabriel C. Ullmann
- * @date 2025-04-23
+ * @date 2025-05-27
  */
 public abstract class AbstractOperation<E> extends AbstractEntity implements IOperation<E> {
 
@@ -32,7 +32,6 @@ public abstract class AbstractOperation<E> extends AbstractEntity implements IOp
 
 	@Override
 	public void notifyObservers() {
-
 		for (final Iterator<IRunner> iterator = this.runners.iterator(); iterator.hasNext();) {
 			final IRunner runner = iterator.next();
 			runner.newOperationApplied(this);

--- a/Middleware/src/main/java/ca/concordia/encs/citydata/core/implementations/AbstractProducer.java
+++ b/Middleware/src/main/java/ca/concordia/encs/citydata/core/implementations/AbstractProducer.java
@@ -38,7 +38,7 @@ import ca.concordia.encs.citydata.core.utils.RequestOptions;
  * files and URLs and notifying runners
  * 
  * @author Gabriel C. Ullmann
- * @date 2025-04-23
+ * @date 2025-05-27
  */
 public abstract class AbstractProducer<E> extends AbstractEntity implements IProducer<E> {
 
@@ -77,14 +77,9 @@ public abstract class AbstractProducer<E> extends AbstractEntity implements IPro
 
 	@Override
 	public void notifyObservers() {
-		try {
-			for (final Iterator<IRunner> iterator = this.runners.iterator(); iterator.hasNext();) {
-
-				final IRunner runner = iterator.next();
-				runner.newDataAvailable(this);
-			}
-		} catch (final Exception e) {
-			e.printStackTrace();
+		for (final Iterator<IRunner> iterator = this.runners.iterator(); iterator.hasNext();) {
+			final IRunner runner = iterator.next();
+			runner.newDataAvailable(this);
 		}
 	}
 

--- a/Middleware/src/main/java/ca/concordia/encs/citydata/runners/SequentialRunner.java
+++ b/Middleware/src/main/java/ca/concordia/encs/citydata/runners/SequentialRunner.java
@@ -29,7 +29,7 @@ import ca.concordia.encs.citydata.producers.ExceptionProducer;
  * then proceeds to the next Operation until all operations are completed.
  *
  * @author Gabriel C. Ullmann
- * @date 2025-02-14
+ * @date 2025-05-27
  */
 @Component
 public class SequentialRunner extends AbstractRunner implements IRunner {
@@ -128,12 +128,10 @@ public class SequentialRunner extends AbstractRunner implements IRunner {
 				this.applyNextOperation(producer);
 			}
 		} catch (Exception e) {
+			// stop runner as soon as an exception is thrown to avoid infinite loops
 			InMemoryDataStore store = InMemoryDataStore.getInstance();
 			store.set(this.getId(), new ExceptionProducer(e));
-
-			// stop runner as soon as an exception is thrown to avoid infinite loops
 			this.setAsDone();
-			System.out.println(e.getMessage());
 		}
 
 	}

--- a/Middleware/src/main/java/ca/concordia/encs/citydata/runners/SingleStepRunner.java
+++ b/Middleware/src/main/java/ca/concordia/encs/citydata/runners/SingleStepRunner.java
@@ -22,7 +22,7 @@ import ca.concordia.encs.citydata.producers.ExceptionProducer;
  * are applying (e.g. MergeOperation).
  * 
  * Author: Gabriel C. Ullmann 
- * Date: 2025-02-14
+ * Date: 2025-05-27
  */
 public class SingleStepRunner extends AbstractRunner implements IRunner {
 
@@ -92,12 +92,10 @@ public class SingleStepRunner extends AbstractRunner implements IRunner {
 			this.setAsDone();
 			System.out.println("Run completed!");
 		} catch (Exception e) {
+			// stop runner as soon as an exception is thrown to avoid infinite loops
 			InMemoryDataStore store = InMemoryDataStore.getInstance();
 			store.set(this.getMetadataString("id"), new ExceptionProducer(e));
-
-			// stop runner as soon as an exception is thrown to avoid infinite loops
 			this.setAsDone();
-			System.out.println(e.getMessage());
 		}
 	}
 


### PR DESCRIPTION
The issue is described in #93 . While studying the problem I realized we do not really need the throw in newAvailableData because the exception is already handled within newAvailableData. By removing this throw, we can also remove the try/catch from notifyObservers.
